### PR TITLE
Added mercy rule

### DIFF
--- a/autoleagueplay/__main__.py
+++ b/autoleagueplay/__main__.py
@@ -25,7 +25,6 @@ Options:
     --version                    Show version.
     --skip-stale-rematches       Skip matches when the same versions of both bots have already played each other.
 """
-import datetime
 import sys
 from pathlib import Path
 

--- a/autoleagueplay/key_macros.py
+++ b/autoleagueplay/key_macros.py
@@ -1,26 +1,42 @@
+import time
+
 from pywinauto.application import Application
 
 
-def press_h():
+def hide_hud_macro():
     app = Application()
     app.connect(title_re='Rocket League.*')
     win = app.window_(title_re='Rocket League.*')
     win.type_keys("{h down}" "{h up}")
 
-def press_9():
+
+def do_director_spectating_macro():
     app = Application()
     app.connect(title_re='Rocket League.*')
     win = app.window_(title_re='Rocket League.*')
     win.type_keys("{9 down}" "{9 up}")
 
-def press_pg_dwn():
+
+def hide_rendering_macro():
     app = Application()
     app.connect(title_re='Rocket League.*')
     win = app.window_(title_re='Rocket League.*')
     win.type_keys("{PGDN down}" "{PGDN up}")
 
-def press_home():
+
+def show_percentages_macro():
     app = Application()
     app.connect(title_re='Rocket League.*')
     win = app.window_(title_re='Rocket League.*')
     win.type_keys("{HOME down}" "{HOME up}")
+
+
+def end_game_macro(save_a_qued_replay: bool):
+    app = Application()
+    app.connect(title_re='Rocket League.*')
+    win = app.window_(title_re='Rocket League.*')
+    for cmd in ["{ESC}", "{VK_UP}", "{ENTER}", "{VK_LEFT}", "{ENTER}"]:
+        win.type_keys(cmd)
+        time.sleep(0.1)
+    if save_a_qued_replay:
+        win.type_keys("{ENTER}")

--- a/autoleagueplay/match_exercise.py
+++ b/autoleagueplay/match_exercise.py
@@ -20,7 +20,7 @@ from autoleagueplay.key_macros import hide_hud_macro, do_director_spectating_mac
 @dataclass
 class MercyRule:
 
-    required_goal_diff: int = 6
+    required_goal_diff: int = 7
     game_interface: GameInterface = None
 
     mercy_detected: bool = False

--- a/autoleagueplay/match_exercise.py
+++ b/autoleagueplay/match_exercise.py
@@ -1,9 +1,12 @@
+import time
 from dataclasses import dataclass, field
 from typing import Optional
 
+from rlbot.setup_manager import SetupManager
 from rlbot.training.training import Grade, Pass, Fail
 from rlbot.utils.game_state_util import GameState
 from rlbot.utils.structures.game_data_struct import GameTickPacket
+from rlbot.utils.structures.game_interface import GameInterface
 from rlbottraining.grading.grader import Grader
 from rlbottraining.grading.training_tick_packet import TrainingTickPacket
 from rlbottraining.rng import SeededRandomNumberGenerator
@@ -11,7 +14,34 @@ from rlbottraining.training_exercise import TrainingExercise
 
 from autoleagueplay.match_result import MatchResult
 from autoleagueplay.replays import ReplayPreference, ReplayMonitor
-from autoleagueplay.spectator_hud import press_h, press_9, press_pg_dwn, press_home
+from autoleagueplay.key_macros import hide_hud_macro, do_director_spectating_macro, hide_rendering_macro, show_percentages_macro, end_game_macro
+
+
+@dataclass
+class MercyRule:
+
+    required_goal_diff: int = 6
+    game_interface: GameInterface = None
+
+    mercy_detected: bool = False
+    game_ended: bool = False
+
+    def check_for_mercy(self, packet: GameTickPacket):
+        blue_score = packet.teams[0].score
+        orange_score = packet.teams[1].score
+
+        # The mercy is detected as soon as the goal is scored. We want to watch the replay of the goal so
+        # the match is terminated once we see the following kickoff
+        if abs(blue_score - orange_score) >= self.required_goal_diff and not self.mercy_detected:
+            self.que_save_replay()
+            self.mercy_detected = True
+        elif not self.game_ended and packet.game_info.is_kickoff_pause and self.mercy_detected:
+            self.game_ended = True
+            end_game_macro(True)
+
+    def que_save_replay(self):
+        game_state = GameState(console_commands=["QueSaveReplay"])
+        self.game_interface.set_game_state(game_state)
 
 
 class FailDueToNoReplay(Fail):
@@ -22,6 +52,7 @@ class FailDueToNoReplay(Fail):
 @dataclass
 class MatchGrader(Grader):
 
+    mercy_rule: MercyRule = field(default_factory=MercyRule)
     replay_monitor: ReplayMonitor = field(default_factory=ReplayMonitor)
 
     last_match_time: float = 0
@@ -33,12 +64,24 @@ class MatchGrader(Grader):
 
     def on_tick(self, tick: TrainingTickPacket) -> Optional[Grade]:
         if not self.has_pressed_h:
-            press_h()
-            press_9()
-            press_home()
-            press_pg_dwn()
+            hide_hud_macro()
+            do_director_spectating_macro()
+            show_percentages_macro()
+            hide_rendering_macro()
             self.has_pressed_h = True
+
         self.replay_monitor.ensure_monitoring()
+
+        # Check for mercy rule
+        self.mercy_rule.check_for_mercy(tick.game_tick_packet)
+        if self.mercy_rule.game_ended:
+            self.match_result = fetch_match_score(tick.game_tick_packet)
+            time.sleep(1)  # Give time for replay_monitor to register replay and for RL to load main menu
+            if self.replay_monitor.replay_id or self.replay_monitor.replay_preference == ReplayPreference.IGNORE_REPLAY:
+                self.replay_monitor.stop_monitoring()
+                return Pass()
+
+        # Check if game is over and replay recorded
         self.last_game_tick_packet = tick.game_tick_packet
         game_info = tick.game_tick_packet.game_info
         if game_info.is_match_ended and self.saw_active_packets:

--- a/autoleagueplay/run_matches.py
+++ b/autoleagueplay/run_matches.py
@@ -9,7 +9,7 @@ from autoleagueplay.generate_matches import generate_round_robin_matches
 from autoleagueplay.ladder import Ladder
 from autoleagueplay.load_bots import load_all_bots_versioned
 from autoleagueplay.match_configurations import make_match_config
-from autoleagueplay.match_exercise import MatchExercise, MatchGrader
+from autoleagueplay.match_exercise import MatchExercise, MatchGrader, MercyRule
 from autoleagueplay.match_result import CombinedScore, MatchResult
 from autoleagueplay.overlay import OverlayData
 from autoleagueplay.paths import WorkingDir
@@ -19,18 +19,19 @@ logger = get_logger('autoleagueplay')
 
 
 def run_match(participant_1: str, participant_2: str, match_config, replay_preference: ReplayPreference) -> MatchResult:
-
-    # Play the match
-    print(f'Starting match: {participant_1} vs {participant_2}. Waiting for match to finish...')
-    match = MatchExercise(
-        name=f'{participant_1} vs {participant_2}',
-        match_config=match_config,
-        grader=MatchGrader(
-            replay_monitor=ReplayMonitor(replay_preference=replay_preference),
-        )
-    )
-
     with setup_manager_context() as setup_manager:
+
+        # Prepare the match exercise
+        print(f'Starting match: {participant_1} vs {participant_2}. Waiting for match to finish...')
+        match = MatchExercise(
+            name=f'{participant_1} vs {participant_2}',
+            match_config=match_config,
+            grader=MatchGrader(
+                mercy_rule=MercyRule(game_interface=setup_manager.game_interface),
+                replay_monitor=ReplayMonitor(replay_preference=replay_preference),
+            )
+        )
+
         # If any bots have signed up for early start, give them 10 seconds.
         # This is typically enough for Scratch.
         setup_manager.early_start_seconds = 10


### PR DESCRIPTION
The mercy rule kicks in when goal diff is ~~6~~ 7 (we could add the ability to change this or do no mercy). The mercy is detected as soon as the goal is scored, but since we want to include the instant replay of the goal, the match is terminated after the following kickoff instead.

The match replay is saved by calling the console command 'QueSaveReplay'. I tried different ways to stop the match and ensure the replay was saved correctly, but I had most success with a macro that exited the match by pressing ESC, arrow keys, and enter a few times. Which means video recordings wont include the typical post-game scoreboard but instead show the main menu for a second.